### PR TITLE
feat: 멘토 마이페이지 구현

### DIFF
--- a/src/pages/mentor/mypage/index.tsx
+++ b/src/pages/mentor/mypage/index.tsx
@@ -1,9 +1,37 @@
-import { Box, Heading } from '@chakra-ui/react';
+import { Box, SimpleGrid, GridItem, Text } from '@chakra-ui/react';
+import { StatCard } from './ui/StatCard';
+import { MenteeList } from './ui/MenteeList'; // [New] 새로 만든 컴포넌트 import
+import { RecentTaskList } from './ui/RecentTaskList';
+import { CommentList } from './ui/CommentList';
+import { 
+  MOCK_STATS, 
+  MOCK_MY_MENTEES, 
+  MOCK_RECENT_TASKS, 
+  MOCK_RECENT_COMMENTS 
+} from './model/mockMyPageData';
 
 const MentorMyPage = () => {
   return (
-    <Box>
-      <Heading size="lg" mb={4}>마이페이지</Heading>
+    <Box maxW="1200px" mx="auto">
+      <Text fontSize="2xl" fontWeight="bold" mb={6}>마이페이지</Text>
+
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={4} mb={8}>
+        <StatCard label="과제 미확인" count={MOCK_STATS.uncheckedTaskCount} />
+        <StatCard label="피드백 대기" count={MOCK_STATS.pendingFeedbackCount} />
+      </SimpleGrid>
+
+      <Box mb={8}>
+        <MenteeList mentees={MOCK_MY_MENTEES} />
+      </Box>
+
+      <SimpleGrid columns={{ base: 1, lg: 2 }} spacing={6} pb={10}>
+        <GridItem>
+          <RecentTaskList tasks={MOCK_RECENT_TASKS} />
+        </GridItem>
+        <GridItem>
+          <CommentList comments={MOCK_RECENT_COMMENTS} />
+        </GridItem>
+      </SimpleGrid>
     </Box>
   );
 };

--- a/src/pages/mentor/mypage/model/mockMyPageData.ts
+++ b/src/pages/mentor/mypage/model/mockMyPageData.ts
@@ -1,0 +1,67 @@
+import { DashboardStats, MenteeSummary, RecentFeedbackComment, RecentSubmittedTask } from './types';
+
+export const MOCK_STATS: DashboardStats = {
+  uncheckedTaskCount: 5,
+  pendingFeedbackCount: 12,
+};
+
+export const MOCK_MY_MENTEES: MenteeSummary[] = [
+  {
+    id: 'mentee-1',
+    name: '이멘티',
+    profileImgUrl: 'https://bit.ly/ryan-florence',
+    achievement: { korean: 80, english: 45, math: 90 },
+  },
+  {
+    id: 'mentee-2',
+    name: '박공부',
+    profileImgUrl: null,
+    achievement: { korean: 60, english: 75, math: 50 },
+  },
+  {
+    id: 'mentee-3',
+    name: '최수학',
+    profileImgUrl: 'https://bit.ly/code-beast',
+    achievement: { korean: 40, english: 30, math: 95 },
+  },
+];
+
+export const MOCK_RECENT_TASKS: RecentSubmittedTask[] = [
+  {
+    id: 'task-101',
+    title: '비문학 지문 분석',
+    subject: 'KOREAN',
+    menteeId: 'mentee-1',
+    menteeName: '이멘티',
+    submittedAt: '2024-02-14T10:30:00',
+  },
+  {
+    id: 'task-102',
+    title: '미적분 30번 문제 풀이',
+    subject: 'MATH',
+    menteeId: 'mentee-3',
+    menteeName: '최수학',
+    submittedAt: '2024-02-14T09:15:00',
+  },
+];
+
+export const MOCK_RECENT_COMMENTS: RecentFeedbackComment[] = [
+  {
+    id: 'comment-1',
+    content: '선생님, 이 부분 이해가 잘 안 돼요 ㅠㅠ',
+    menteeId: 'mentee-2',
+    menteeName: '박공부',
+    taskId: 'task-99',
+    feedbackId: 'fb-1',
+    createdAt: '2024-02-13T20:00:00',
+  },
+  {
+    id: 'comment-2',
+    content: '넵 알겠습니다! 수정해서 다시 올릴게요.',
+    menteeId: 'mentee-1',
+    menteeName: '이멘티',
+    taskId: 'task-88',
+    feedbackId: 'fb-2',
+    createdAt: '2024-02-13T18:30:00',
+  },
+];

--- a/src/pages/mentor/mypage/model/types.ts
+++ b/src/pages/mentor/mypage/model/types.ts
@@ -1,0 +1,34 @@
+export interface DashboardStats {
+  uncheckedTaskCount: number;
+  pendingFeedbackCount: number;
+}
+
+export interface MenteeSummary {
+  id: string;
+  name: string;
+  profileImgUrl?: string | null;
+  achievement: {
+    korean: number;
+    english: number;
+    math: number;
+  };
+}
+
+export interface RecentSubmittedTask {
+  id: string;
+  title: string;
+  subject: string; 
+  menteeId: string;
+  menteeName: string;
+  submittedAt: string;
+}
+
+export interface RecentFeedbackComment {
+  id: string;
+  content: string;
+  menteeId: string;
+  menteeName: string;
+  taskId: string;
+  feedbackId: string;
+  createdAt: string;
+}

--- a/src/pages/mentor/mypage/ui/CommentList.tsx
+++ b/src/pages/mentor/mypage/ui/CommentList.tsx
@@ -1,0 +1,53 @@
+import { Box, Text, VStack, Flex, Avatar, Icon } from '@chakra-ui/react';
+import { ChevronRightIcon } from '@chakra-ui/icons';
+import { RecentFeedbackComment } from '../model/types';
+import { useNavigate } from 'react-router-dom';
+
+interface Props {
+  comments: RecentFeedbackComment[];
+}
+
+export const CommentList = ({ comments }: Props) => {
+  const navigate = useNavigate();
+
+  return (
+    <Box>
+      <Text fontSize="lg" fontWeight="bold" mb={4}>새로 달린 댓글</Text>
+      
+      <VStack spacing={3} align="stretch">
+        {comments.map((comment) => (
+          <Flex
+            key={comment.id}
+            bg="white" 
+            p={4}
+            borderRadius="3xl"
+            border="1px solid"
+            borderColor="gray.100"
+            align="center"
+            cursor="pointer"
+            transition="all 0.2s"
+            _hover={{ transform: 'translateY(-2px)', boxShadow: 'sm' }}
+            onClick={() => navigate(`/mentor/mentee/${comment.menteeId}/task/${comment.taskId}?feedbackId=${comment.feedbackId}`)}
+          >
+            <VStack spacing={1} mr={5} minW="50px">
+              <Avatar size="sm" name={comment.menteeName} src={undefined} bg="gray.200" />
+              <Text fontSize="xs" color="gray.500">{comment.menteeName}</Text>
+            </VStack>
+
+            <Text fontSize="md" fontWeight="bold" color="gray.700" flex={1} noOfLines={1}>
+              {comment.content}
+            </Text>
+
+            <Icon as={ChevronRightIcon} color="gray.400" w={6} h={6} ml={3} />
+          </Flex>
+        ))}
+
+        {comments.length === 0 && (
+          <Text color="gray.400" fontSize="sm" textAlign="center" py={4}>
+            새로운 댓글이 없습니다.
+          </Text>
+        )}
+      </VStack>
+    </Box>
+  );
+};

--- a/src/pages/mentor/mypage/ui/MenteeCard.tsx
+++ b/src/pages/mentor/mypage/ui/MenteeCard.tsx
@@ -1,0 +1,73 @@
+import { Box, Flex, Text, Avatar, VStack, Progress } from '@chakra-ui/react';
+import { MenteeSummary } from '../model/types';
+import { useNavigate } from 'react-router-dom';
+
+interface Props {
+  mentee: MenteeSummary;
+}
+
+export const MenteeCard = ({ mentee }: Props) => {
+  const navigate = useNavigate();
+
+  return (
+    <Box
+      minW="330px"
+      h="150px" // 높이를 150px로 고정 (또는 minH="150px")
+      bg="white"
+      p={5}
+      borderRadius="2xl"
+      border="1px solid"
+      borderColor="gray.100"
+      boxShadow="sm"
+      cursor="pointer"
+      transition="all 0.2s"
+      _hover={{ transform: 'translateY(-4px)', boxShadow: 'md' }}
+      onClick={() => navigate(`/mentor/mentee/${mentee.id}`)}
+      display="flex"         
+      alignItems="center"  
+    >
+      <Flex align="center" w="full">
+        <Avatar
+          size="xl"
+          name={mentee.name}
+          src={mentee.profileImgUrl || undefined}
+          mr={6} 
+        />
+
+        <VStack align="stretch" spacing={3} flex={1} justify="center">
+          <Text fontWeight="extrabold" fontSize="lg" lineHeight="1">
+            {mentee.name}님
+          </Text>
+
+          <VStack spacing={2} align="stretch">
+            <AchievementRow label="국" value={mentee.achievement.korean} colorScheme="blue" />
+            <AchievementRow label="영" value={mentee.achievement.english} colorScheme="green" />
+            <AchievementRow label="수" value={mentee.achievement.math} colorScheme="purple" />
+          </VStack>
+        </VStack>
+      </Flex>
+    </Box>
+  );
+};
+
+const AchievementRow = ({ label, value, colorScheme }: { label: string; value: number; colorScheme: string }) => (
+  <Flex align="center">
+    <Text fontSize="sm" fontWeight="bold" color="gray.500" w="20px" mb="1px">
+      {label}
+    </Text>
+    <Box flex={1} ml={3}>
+      <Progress
+        value={value}
+        height="8px" 
+        colorScheme={colorScheme}
+        borderRadius="full"
+        bg="gray.100"
+        sx={{
+            '& > div': {
+                transition: 'width 0.5s ease-in-out',
+            }
+        }}
+      />
+    </Box>
+  </Flex>
+);

--- a/src/pages/mentor/mypage/ui/MenteeList.tsx
+++ b/src/pages/mentor/mypage/ui/MenteeList.tsx
@@ -1,0 +1,90 @@
+import { useRef } from 'react';
+import { Box, HStack, IconButton, Text } from '@chakra-ui/react';
+import { ChevronLeftIcon, ChevronRightIcon } from '@chakra-ui/icons';
+import { MenteeSummary } from '../model/types';
+import { MenteeCard } from './MenteeCard';
+
+interface Props {
+  mentees: MenteeSummary[];
+}
+
+export const MenteeList = ({ mentees }: Props) => {
+  const scrollContainerRef = useRef<HTMLDivElement>(null);
+
+  const handleScroll = (direction: 'left' | 'right') => {
+    if (scrollContainerRef.current) {
+      const scrollAmount = 350; 
+      const currentScroll = scrollContainerRef.current.scrollLeft;
+      
+      scrollContainerRef.current.scrollTo({
+        left: direction === 'left' ? currentScroll - scrollAmount : currentScroll + scrollAmount,
+        behavior: 'smooth',
+      });
+    }
+  };
+
+  return (
+    <Box>
+      <Text fontSize="lg" fontWeight="bold" mb={4}>담당 멘티</Text>
+      
+      <Box position="relative">
+        <IconButton
+          aria-label="Scroll Left"
+          icon={<ChevronLeftIcon w={6} h={6} />}
+          position="absolute"
+          left={4}
+          top="50%"
+          transform="translateY(-50%)"
+          zIndex={10}
+          isRound
+          size="sm"
+          bg="white"
+          shadow="md"
+          border="1px solid"
+          borderColor="gray.100"
+          color="gray.500"
+          _hover={{ bg: 'gray.50', color: 'gray.700' }}
+          onClick={() => handleScroll('left')}
+          display={{ base: 'none', md: 'flex' }}
+        />
+
+        <HStack
+          ref={scrollContainerRef}
+          spacing={6} 
+          overflowX="auto"
+          py={4}
+          px={20}
+          mx={-6}
+          css={{
+            '&::-webkit-scrollbar': { display: 'none' },
+            scrollbarWidth: 'none',
+          }}
+        >
+          {mentees.map((mentee) => (
+            <MenteeCard key={mentee.id} mentee={mentee} />
+          ))}
+        </HStack>
+
+        <IconButton
+          aria-label="Scroll Right"
+          icon={<ChevronRightIcon w={6} h={6} />}
+          position="absolute"
+          right={4} 
+          top="50%"
+          transform="translateY(-50%)"
+          zIndex={10}
+          isRound
+          size="sm"
+          bg="white"
+          shadow="md"
+          border="1px solid"
+          borderColor="gray.100"
+          color="gray.500"
+          _hover={{ bg: 'gray.50', color: 'gray.700' }}
+          onClick={() => handleScroll('right')}
+          display={{ base: 'none', md: 'flex' }}
+        />
+      </Box>
+    </Box>
+  );
+};

--- a/src/pages/mentor/mypage/ui/RecentTaskList.tsx
+++ b/src/pages/mentor/mypage/ui/RecentTaskList.tsx
@@ -1,0 +1,80 @@
+import { Box, Text, VStack, Badge, Flex, Avatar, Icon } from '@chakra-ui/react';
+import { ChevronRightIcon } from '@chakra-ui/icons';
+import { RecentSubmittedTask } from '../model/types';
+import { useNavigate } from 'react-router-dom';
+
+interface Props {
+  tasks: RecentSubmittedTask[];
+}
+
+const SUBJECT_COLOR: Record<string, string> = {
+  KOREAN: 'blue',
+  MATH: 'purple',
+  ENGLISH: 'green',
+  OTHER: 'gray',
+};
+
+const SUBJECT_LABEL: Record<string, string> = {
+  KOREAN: '국어',
+  MATH: '수학',
+  ENGLISH: '영어',
+  OTHER: '기타',
+};
+
+export const RecentTaskList = ({ tasks }: Props) => {
+  const navigate = useNavigate();
+
+  return (
+    <Box>
+      <Text fontSize="lg" fontWeight="bold" mb={4}>최근 제출된 과제</Text>
+      
+      <VStack spacing={3} align="stretch">
+        {tasks.map((task) => (
+          <Flex
+            key={task.id}
+            bg="white"
+            p={4}
+            borderRadius="3xl"
+            border="1px solid"
+            borderColor="gray.100"
+            align="center"
+            cursor="pointer"
+            transition="all 0.2s"
+            _hover={{ transform: 'translateY(-2px)', boxShadow: 'sm' }}
+            onClick={() => navigate(`/mentor/mentee/${task.menteeId}/task/${task.id}`)}
+          >
+            <VStack spacing={1} mr={5} minW="50px">
+              <Avatar size="sm" name={task.menteeName} src={undefined} bg="gray.200" />
+              <Text fontSize="xs" color="gray.500">{task.menteeName}</Text>
+            </VStack>
+
+            <Text fontSize="md" fontWeight="bold" color="gray.700" flex={1} isTruncated>
+              {task.title}
+            </Text>
+
+            <Flex align="center" ml={2}>
+              <Badge
+                colorScheme={SUBJECT_COLOR[task.subject] || 'gray'}
+                variant="solid"
+                borderRadius="full" 
+                px={4}
+                py={1}
+                fontSize="sm"
+                fontWeight="bold"
+              >
+                {SUBJECT_LABEL[task.subject] || task.subject}
+              </Badge>
+              <Icon as={ChevronRightIcon} color="gray.400" w={6} h={6} ml={3} />
+            </Flex>
+          </Flex>
+        ))}
+        
+        {tasks.length === 0 && (
+          <Text color="gray.400" fontSize="sm" textAlign="center" py={4}>
+            제출된 과제가 없습니다.
+          </Text>
+        )}
+      </VStack>
+    </Box>
+  );
+};

--- a/src/pages/mentor/mypage/ui/StatCard.tsx
+++ b/src/pages/mentor/mypage/ui/StatCard.tsx
@@ -1,0 +1,33 @@
+import { Flex, Text } from '@chakra-ui/react';
+
+interface Props {
+  label: string;
+  count: number;
+}
+
+export const StatCard = ({ label, count }: Props) => {
+  return (
+    <Flex
+      p={5}
+      align="center"
+      gap={2}
+      h="full"
+    >
+      <Text fontSize="md" fontWeight="bold" color="gray.600">
+        {label}
+      </Text>
+      
+      <Flex
+        padding="1px 12px"
+        bg="#373E56"
+        borderRadius="full"
+        align="center"
+        justify="center"
+      >
+        <Text color="white" fontWeight="semibold" fontSize="16px">
+          {count}
+        </Text>
+      </Flex>
+    </Flex>
+  );
+};


### PR DESCRIPTION
## 주요 변경 사항

### 1. 페이지 및 라우팅 (`/pages/mentor/mypage`)
- `/mentor` 경로 접속 시 **마이페이지**가 렌더링되도록 변경.
- 기존 `MentorDashboardPage` 제거 및 `MentorMyPage`로 대체.
- `MockData` 및 데이터 타입(`MenteeSummary`, `DashboardStats` 등) 정의.

### 2. UI 컴포넌트 구현 (`/ui`)
- **StatCard**: 과제 미확인/피드백 대기 건수를 '검정색 원형 뱃지' 스타일로 심플하게 표시.
- **MenteeList & MenteeCard**:
  - 담당 멘티 정보를 가로 스크롤 형태로 조회.
  - **좌/우 커스텀 버튼**을 구현하여 스크롤 편의성 증대 (모바일은 터치 스크롤).
  - 멘티 성취도(국/영/수)를 **게이지 바(Progress Bar)** 형태로 시각화 (퍼센트 텍스트 제거).
  - 카드 높이 및 레이아웃 최적화 (아바타 수직 중앙 정렬).
- **RecentTaskList**:
  - 최근 제출된 과제를 둥근 모서리의 카드 리스트로 구현.
  - 과목별 **Solid 스타일 뱃지** 적용.
- **CommentList**:
  - 멘티가 남긴 최근 댓글을 조회하는 리스트 구현.

### 3. 스타일 및 UX 개선
- **가로 스크롤**: `MenteeList` 양옆에 여백(`px={20}`)을 충분히 주어 스크롤 버튼과 카드 간의 간섭 방지.
- **반응형**: 데스크탑에서는 스크롤 버튼 노출, 모바일에서는 숨김 처리.
- **Hover 효과**: 각 리스트 아이템에 마우스 오버 시 부드러운 인터랙션 추가.

## 스크린샷
<img width="1094" height="592" alt="image" src="https://github.com/user-attachments/assets/5a2735fe-8ccd-49c4-a132-4b4c403003b5" />

## 테스트 방법
1. 멘토 계정으로 로그인 (`/mentor` 진입).
2. 상단 통계 카드(검정 뱃지) 확인.
3. 담당 멘티 리스트의 좌/우 버튼을 눌러 가로 스크롤 동작 확인.
4. 멘티 카드 클릭 시 멘티 상세 페이지(`/mentor/mentee/:id`) 이동 확인.
5. 최근 과제 및 댓글 리스트 UI 확인 및 클릭 시 이동 확인.